### PR TITLE
Change Github repo pointer for xmlsec

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -71,7 +71,7 @@
   </autotools>
 
   <autotools id="xmlsec">
-    <branch module="GNOME/xmlsec" repo="github"/>
+    <branch module="lsh123/xmlsec" repo="github"/>
     <dependencies>
       <dep package="openssl"/>
     </dependencies>


### PR DESCRIPTION
If you clone the existing repository at git://github.com/GNOME/xmlsec,
you get a README indicating that the new location for the code is
https://github.com/lsh123/xmlsec.

This change is also mentioned in the NEWS section of 
https://www.aleksey.com/xmlsec
