### PR TITLE
Categorize the Mac build as public.app-category.finance

### DIFF
--- a/gnucash-bundler/Info-unstable.plist
+++ b/gnucash-bundler/Info-unstable.plist
@@ -59,6 +59,8 @@
 	<true/>
 	<key>LSRequiresCarbon</key>
 	<true/>
+	<key>LSApplicationCategoryType<key>
+	<string>public.app-category.finance<string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2013 Gnucash Contributors</string>
 	<key>NSHighResolutionCapable</key>

--- a/gnucash-bundler/Info.plist
+++ b/gnucash-bundler/Info.plist
@@ -59,6 +59,8 @@
 	<true/>
 	<key>LSRequiresCarbon</key>
 	<true/>
+	<key>LSApplicationCategoryType<key>
+	<string>public.app-category.finance<string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2016 Gnucash Contributors</string>
 	<key>NSHighResolutionCapable</key>


### PR DESCRIPTION
If found this request on uservoice
https://gnucash.uservoice.com/admin/forums/101223-feature-request/suggestions/5720328-categorize-the-mac-build-as-public-app-category-fi#/comments
and figured this should be an easy fix. Provided of course it's the right thing to do and I did it properly. Hence the PR...
