### PR TITLE
Set environment variable GNC_SHELL

### DIFF
--- a/.jhbuildrc-custom
+++ b/.jhbuildrc-custom
@@ -59,3 +59,5 @@ append_autogenargs("libiconv", "--with-libintl-prefix=" + prefix)
 #Tell fontconfig where to find fonts and to not set a cache directory in prefix:
 append_autogenargs("fontconfig", "--with-default-fonts=/Library/Fonts --with-cache-dir=home")
 module_makecheck["gmp"] = True
+
+os.environ["GNC_SHELL"] = os.path.join(prefix, 'bin', 'bash')


### PR DESCRIPTION
This will be used to override the SHELL variable to circumvent MacOS' System Integerty Protection in the gnucash build step

As I no longer have a modern MacOS system available I can't verify whether this is the proper way to set an environment variable in the jhbuild environment.