### PR TITLE
Use correct jhbuild /bin/bash path

### DIFF
--- a/jhbuildrc-custom
+++ b/jhbuildrc-custom
@@ -51,4 +51,4 @@ append_autogenargs("libiconv", "--with-libintl-prefix=" + prefix)
 append_autogenargs("fontconfig", "--with-default-fonts=/Library/Fonts --with-cache-dir=home")
 module_makecheck["gmp"] = True
 
-os.environ["GNC_SHELL"] = os.path.join(prefix, 'bin', 'bash')
+os.environ["GNC_SHELL"] = os.path.join(os.environ['DEVPREFIX'], 'bin', 'bash')


### PR DESCRIPTION
`prefix` is set to `~/src/gnucash-[un]stable`, but `gtk-osx-setup.sh` adds the bash symlink to `~/.new_local/bin/bash`. `~/.new_local` is available in env variable `$DEVPREFIX` inside of jhbuild. I needed this, otherwise my build was broken: the `utils/gnc-vcs-info` was being invoked with the (nonexistent) `~/src/gnucash-unstable/bin/bash` and always erroring-out. This in turn had knock-on effects to not generate swig bindings and the build failed.

Not sure if the packaging/AppBundle logic needs to be updated, too.