### PR TITLE
Update aqbanking to 6.2.3beta

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -87,7 +87,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="334/aqbanking-6.2.2.tar.gz" version="6.2.2"
+    <branch module="338/aqbanking-6.2.3beta.tar.gz" version="6.2.3beta"
             repo="aqbanking">
     </branch>
     <dependencies>


### PR DESCRIPTION
Delayed, see https://github.com/Gnucash/gnucash-on-flatpak/pull/3, and test build still required.