### PR TITLE
Update to aqbanking-6.2.10

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -87,7 +87,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="366/aqbanking-6.2.9.tar.gz" version="6.2.9"
+    <branch module="368/aqbanking-6.2.10.tar.gz" version="6.2.10"
             repo="aqbanking">
     </branch>
     <dependencies>


### PR DESCRIPTION
Fix wrong error message in PIN/TAN, see threads
https://lists.gnucash.org/pipermail/gnucash-de/2021-March/012076.html
and
https://lists.gnucash.org/pipermail/gnucash-de/2021-February/012027.html