### PR TITLE
Update libofx to 0.10.2

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -129,8 +129,8 @@
   </autotools>
 
   <autotools id="libofx" autogen-sh='configure'>
-    <branch repo="sourceforge" module="libofx/libofx-0.10.1.tar.gz"
-	    version="0.10.1"/>
+    <branch repo="sourceforge" module="libofx/libofx-0.10.2.tar.gz"
+	    version="0.10.2"/>
     <dependencies>
       <dep package="OpenSP"/>
     </dependencies>


### PR DESCRIPTION
Addresses underlying causes of GnuCash bugs
https://bugs.gnucash.org/show_bug.cgi?id=636340 and
https://bugs.gnucash.org/show_bug.cgi?id=797848