### PR TITLE
Update to aqbanking-6.3.0

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -91,7 +91,7 @@
 
   <autotools id="aqbanking" autogen-sh="autoreconf" makeargs="-j1"
 	     autogenargs="--enable-local-install">
-    <branch module="368/aqbanking-6.2.10.tar.gz" version="6.2.10"
+    <branch module="372/aqbanking-6.3.0.tar.gz" version="6.3.0"
             repo="aqbanking">
     </branch>
     <dependencies>


### PR DESCRIPTION
Log all jobs in $HOME/.aqbanking/jobs/
- independent from
-- logging or debugging settings,
-- the calling application.
- currently verbose for FinTS
- to easier retrace what happened to the respective orders