### PR TITLE
Remove spurious %s from jhbuildrc-custom stdout

### DIFF
--- a/jhbuildrc-custom
+++ b/jhbuildrc-custom
@@ -9,7 +9,7 @@ else:
 
 checkoutroot = os.path.join(os.path.dirname(prefix), 'src')
 buildroot = os.path.join(os.path.dirname(prefix), 'build')
-print("Building in %s", buildroot)
+print("Building in", buildroot)
 moduleset = "https://github.com/gnucash/gnucash-on-osx/raw/master/modulesets/gnucash.modules"
 
 _modules_deps = ['pygments', 'meta-gtk-osx-bootstrap', 'meta-gtk-osx-gtk3',


### PR DESCRIPTION
jhbuildrc-custom prints a message to stdout, "Building in %s /Users/gtkdeveloper/gnucash/build". The "%s" is a typo, I suspect. 

I believe this edit to be low-risk, but I have not yet tested it.