### PR TITLE
Update xmlsec1 to 1.3.9

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -87,8 +87,8 @@
   </autotools>
 
   <autotools id="xmlsec" autogenargs="--enable-docs=no --with-gcrypt --with-gnutls">
-    <branch module="xmlsec1-1.3.7.tar.gz"
-            repo="xmlsec" version="1.3.7" >
+    <branch module="xmlsec1-1.3.9.tar.gz"
+            repo="xmlsec" version="1.3.9" >
     </branch>
     <dependencies>
       <dep package="openssl"/>


### PR DESCRIPTION
1.3.7 is no longer available in the repository.