### PR TITLE
Configure lib/include paths for libofx and libdbi-drivers

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -138,7 +138,8 @@
     </branch>
   </autotools>
 
-  <autotools id="libofx" autogen-sh='configure'>
+  <autotools id="libofx" autogen-sh='configure'
+	     autogenargs="--with-opensp-libs=$PREFIX/lib/ --with-opensp-includes=$PREFIX/include/OpenSP/">
     <branch repo="github-tarball" module="libofx/libofx/releases/download/0.10.9/libofx-0.10.9.tar.gz"
             version="0.10.9">
     </branch>
@@ -186,7 +187,7 @@
   </autotools>
 
   <autotools id="libdbi-drivers" autogen-sh="configure"
-	     autogenargs='--with-mysql --with-mysql-libdir=$PREFIX/lib/mariadb/  --with-mysql-incdir=$PREFIX/include/mariadb/ --with-pgsql --with-sqlite3 --disable-docs --disable-dependency-tracking'>
+	     autogenargs='--with-mysql --with-mysql-libdir=$PREFIX/lib/mariadb/  --with-mysql-incdir=$PREFIX/include/mariadb/ --with-pgsql --with-sqlite3 --disable-docs --disable-dependency-tracking --with-dbi-libdir=$PREFIX/lib --with-dbi-incdir=$PREFIX/include/dbi/'>
     <branch repo="sourceforge"
             module="gnucash/libdbi-drivers-0.9.1.tar.gz" version="0.9.1"
             hash="sha256:3346b3f09edb2c2464422560ff783f7a7fa1fcd287427f0a8f2db8a1d995acb9">


### PR DESCRIPTION
Both of these seem to ignore $PREFIX by default when searching for the OpenSP and libdbi dependencies, respectively. Explicitly configure the path so they can be found.