### PR TITLE
Ignore libdbi-driver compiler warning

### DIFF
--- a/modulesets/gnucash.modules
+++ b/modulesets/gnucash.modules
@@ -190,6 +190,7 @@
     <branch repo="sourceforge"
             module="gnucash/libdbi-drivers-0.9.1.tar.gz" version="0.9.1"
             hash="sha256:3346b3f09edb2c2464422560ff783f7a7fa1fcd287427f0a8f2db8a1d995acb9">
+      <patch file="libdbi-drivers-cgreen.patch" strip="1"/>
     </branch>
     <dependencies>
       <dep package="libdbi"/>

--- a/patches/libdbi-drivers-cgreen.patch
+++ b/patches/libdbi-drivers-cgreen.patch
@@ -1,0 +1,14 @@
+diff -r -u libdbi-drivers-0.9.1.orig/tests/cgreen/src/constraint.c libdbi-drivers-0.9.1/tests/cgreen/src/constraint.c
+--- a/tests/cgreen/src/constraint.c	2026-01-14 08:32:39
++++ b/tests/cgreen/src/constraint.c	2026-01-14 06:58:22
+@@ -101,7 +101,10 @@
+ 
+     constraint->parameter = parameter;
+     constraint->compare = &compare_using_matcher;
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wincompatible-function-pointer-types"
+     constraint->test = &test_with_matcher;
++#pragma clang diagnostic pop
+     constraint->name = matcher_name;
+     constraint->expected = (intptr_t)matcher_function;
+     return constraint;


### PR DESCRIPTION
The signature of test_with_matcher is completely wrong here, but this code is only used for cgreen's self tests, so it doesn't really matter.